### PR TITLE
Implement support for ENV credentials and temporary session tokens.

### DIFF
--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -6,6 +6,7 @@ use std::env;
 pub struct Credentials {
     pub key: Option<String>,
     pub secret: Option<String>,
+    pub token: Option<String>,
     path: String,
     profile: String,
 }
@@ -15,6 +16,7 @@ impl<'a> Credentials {
         Credentials{
             key: None,
             secret: None,
+            token: None,
             path: get_profile_path(),
             profile: get_default_profile(),
         }
@@ -47,6 +49,9 @@ impl<'a> Credentials {
                 };
                 if let Some(secret) = section.get("aws_secret_access_key") {
                     self.secret = Some(secret.to_string())
+                };
+                if let Some(token) = section.get("aws_security_token") {
+                    self.token = Some(token.to_string())
                 }
             }
         };
@@ -56,6 +61,9 @@ impl<'a> Credentials {
 
         if let Ok(secret) = env::var("AWS_SECRET_ACCESS_KEY") {
             self.secret = Some(secret.to_string())
+        };
+        if let Ok(token) = env::var("AWS_SESSION_TOKEN") {
+            self.token = Some(token.to_string())
         };
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![crate_type = "lib"]
 
 #![feature(convert)]
+#![cfg_attr(test, feature(static_rwlock))]
 
 #[macro_use]
 extern crate hyper;

--- a/src/signers/sigv4.rs
+++ b/src/signers/sigv4.rs
@@ -88,6 +88,16 @@ impl<'a> SigV4 {
         self
     }
 
+    fn token(mut self) -> SigV4 {
+        match self.credentials.clone().unwrap().token {
+            Some(token) => {
+                append_header(&mut self.headers, "x-amz-security-token", token.as_ref());
+                self
+            },
+            None => self
+        }
+    }
+
     fn date(mut self) -> SigV4 {
         append_header(&mut self.headers, "x-amz-date",
                       self.date.strftime("%Y%m%dT%H%M%SZ").unwrap().to_string().as_ref());
@@ -109,7 +119,7 @@ impl<'a> SigV4 {
     }
 
     pub fn as_headers(self) -> Headers {
-        let fin = self.date().authorization();
+        let fin = self.date().token().authorization();
         let mut headers = Headers::new();
 
         for h in fin.headers {


### PR DESCRIPTION
This allows you to authenticate using AWS_\* environment variables.
Along with enabling support for authenticating with temporary session tokens returned from the AWS STS API.
